### PR TITLE
Alternative setup for vagrant without needing to clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This allows you to run multiple without needing to clone the repo each time.
 
 1) [Download and install Vagrant][vagrant] 1.2.3 or greater.
 
-2) Install the vagrant "box"
+2) Install the vagrant "box" and get it running
 
 ```
 vagrant init coreos http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_vagrant.box
@@ -33,4 +33,3 @@ vagrant up
 vagrant ssh
 ```
 
-3) Get Started


### PR DESCRIPTION
Additional information for getting vagrant up and running without cloning the repo. The default Vagrantfile template is also used allowing the developer to customise if they're not familiar with vagrant. 
