### PR TITLE
improved vagrant installation instructions - and included virtualbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# CoreOS Vagrant
+# CoreOS Vagrant 
 
-This repo provides a template Vagrantfile for CoreOS. To get a single
-CoreOS node up and running do the following:
+This repo provides a template Vagrantfile to create a CoreOS virtual machine using the Virtualbox virtualizer. 
+After setup is complete you will have a single CoreOS virtual machine running on your local machine.
 
-1) [Download and install Vagrant][vagrant] 1.2.3 or greater.
+## Streamlined setup
+
+1) Install dependencies
+
+* [Virtualbox][virtualbox] 4.0 or greater.
+* [Vagrant][vagrant] 1.2.3 or greater.
 
 2) Clone this project and get it running!
 
@@ -14,14 +19,27 @@ vagrant up
 vagrant ssh
 ```
 
+``vagrant up`` triggers vagrant to download the CoreOS image (if necessary) and (re)launch the 
+instance
+
+``vagrant ssh`` connects you to the virtual machine. Configuration is stored in the 
+directory so you can always return to this machine by executing vagrant ssh from the directory
+where the Vagrantfile was located
+
+
 3) Get started [using CoreOS][using-coreos]
 
+[virtualbox]: https://www.virtualbox.org/
 [vagrant]: http://downloads.vagrantup.com/
 [using-coreos]: http://coreos.com/docs/using-coreos/
 
+
+
 ## Alternative Setup 
 
-This allows you to run multiple without needing to clone the repo each time. 
+This allows you to run multiple instances without needing to clone the repo each time. It will create a 
+Vagrantfile in your current directory and so, you will be able to (re)connect to the virtual 
+machine by returning to this directory and running vagrant ssh.
 
 1) [Download and install Vagrant][vagrant] 1.2.3 or greater.
 


### PR DESCRIPTION
I noticed the installation instructions on the website and this repository do not mention Virtualbox at all and make it sound like CoreOS runs _on_ Vagrant. This confused me at first.

With this rewrite I hope to make it more clear how it actually works. I would also hope to see some to this effect on the http://coreos.com/docs/vagrant/ page. 

http://docs.vagrantup.com/v2/virtualbox/index.html
