### PR TITLE
vbguest error workaround.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,4 +14,9 @@ Vagrant.configure("2") do |config|
   config.vm.provider :vmware_fusion do |vb, override|
     override.vm.box_url = "http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_vagrant_vmware_fusion.box"
   end
+
+  # plugin conflict
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
 end


### PR DESCRIPTION
It is fixed to avoid a problem in the vbguest is one of the popular plug-ins.

An ad hoc basis, this is not a good patch, but because they are not such as side effects, please use if there is a need.

(Because CoreOS does not require any VirtualBox Guest Addtions As I understand it)
