### PR TITLE
refactor(plugin): Use cloud-config to provision networks and hostname

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,8 +37,8 @@ Vagrant.configure("2") do |config|
       #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
 
       if File.exist?(CLOUD_CONFIG_PATH)
-        config.vm.provision :file, :source => "#{CLOUD_CONFIG_PATH}", :destination => "/tmp/user-data"
-        config.vm.provision :shell, :inline => "mkdir -p /var/lib/coreos-vagrant && mv /tmp/user-data /var/lib/coreos-vagrant", :privileged => true
+        config.vm.provision :file, :source => "#{CLOUD_CONFIG_PATH}", :destination => "/tmp/vagrantfile-user-data"
+        config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
       end
 
     end

--- a/override-plugin.rb
+++ b/override-plugin.rb
@@ -5,15 +5,43 @@
 # hack that needs to be removed once the upstream plugin works with
 # alpha CoreOS images.
 
+require 'tempfile'
 require 'ipaddr'
 require Vagrant.source_root.join("plugins/guests/coreos/cap/configure_networks.rb")
 
-UNIT = <<EOF
-[Match]
-Name=%s
+BASE_CLOUD_CONFIG = <<EOF
+#cloud-config
 
-[Network]
-Address=%s
+coreos:
+    units:
+      - name: coreos-cloudinit-vagrant-user.path
+        command: start
+        runtime: no
+        content: |
+          [Path]
+          PathExists=/var/lib/coreos-vagrant/vagrantfile-user-data
+      - name: coreos-cloudinit-vagrant-user.service
+        runtime: no
+        content: |
+          [Unit]
+          ConditionFileNotEmpty=/var/lib/coreos-vagrant/vagrantfile-user-data
+
+          [Service]
+          Type=oneshot
+          EnvironmentFile=/etc/environment
+          ExecStart=/usr/bin/coreos-cloudinit --from-file /var/lib/coreos-vagrant/vagrantfile-user-data
+          RemainAfterExit=yes
+EOF
+
+NETWORK_UNIT = <<EOF
+      - name: %s
+        runtime: no
+        content: |
+          [Match]
+          Name=%s
+
+          [Network]
+          Address=%s
 EOF
 
 # Borrowed from http://stackoverflow.com/questions/1825928/netmask-to-cidr-in-ruby
@@ -30,6 +58,7 @@ module VagrantPlugins
         include Vagrant::Util
 
         def self.configure_networks(machine, networks)
+          cfg = BASE_CLOUD_CONFIG
           machine.communicate.tap do |comm|
 
             # Read network interface names
@@ -38,6 +67,8 @@ module VagrantPlugins
               interfaces = result.split("\n")
             end
 
+            ip = ""
+
             # Configure interfaces
             # FIXME: fix matching of interfaces with IP adresses
             networks.each do |network|
@@ -45,28 +76,39 @@ module VagrantPlugins
               iface_name = interfaces[iface_num]
               cidr = IPAddr.new('255.255.255.0').to_cidr
               address = "%s/%s" % [network[:ip], cidr]
-              unit = UNIT % [iface_name, address]
-              comm.sudo("echo '%s' > /etc/systemd/network/%d-%s.network" % [unit, 10*iface_num, iface_name])
+              unit_name = "50-%s.network" % [iface_name]
+              unit = NETWORK_UNIT % [unit_name, iface_name, address]
 
-              #TODO(bcwaldon): The following sed command is racy with the unit that initially
-              # populates /etc/environment. This line should be reenabled once that race is fixed.
-              #comm.sudo("sed -i -e '/^COREOS_PUBLIC_IPV4=/d' -e '/^COREOS_PRIVATE_IPV4=/d' '/etc/environment'")
-
-              comm.sudo("echo 'COREOS_PUBLIC_IPV4=#{network[:ip]}' >> /etc/environment")
-              comm.sudo("echo 'COREOS_PRIVATE_IPV4=#{network[:ip]}' >> /etc/environment")
+              cfg = "#{cfg}#{unit}"
+              ip = network[:ip]
             end
 
-            # This loads all of our network units we just created
-            comm.sudo("systemctl restart systemd-networkd")
+            cfg = <<EOF
+#{cfg}
+write_files:
+  - path: /etc/environment
+    content: |
+      COREOS_PUBLIC_IPV4=#{ip}
+      COREOS_PRIVATE_IPV4=#{ip}
+
+hostname: #{machine.name}
+EOF
+
+            temp = Tempfile.new("coreos-vagrant")
+            temp.write(cfg)
+            temp.close
+
+            comm.upload(temp.path, "/tmp/user-data")
+            comm.sudo("mkdir -p /var/lib/coreos-vagrant")
+            comm.sudo("mv /tmp/user-data /var/lib/coreos-vagrant/")
 
           end
-
         end
       end
 
       class ChangeHostName
         def self.change_host_name(machine, name)
-            # do nothing!
+          # This is handled in configure_networks
         end
       end
     end


### PR DESCRIPTION
Use the vagrant OEM cloud-config trigger for network, /etc/environment & hostname provisioning before resolving user-provided user-data.
