### PR TITLE
Temporary fix for missing /etc/environment

### DIFF
--- a/override-plugin.rb
+++ b/override-plugin.rb
@@ -94,6 +94,10 @@ write_files:
 hostname: #{machine.name}
 EOF
 
+            #TODO(bcwaldon): Remove `touch /etc/environment` once the following commit is released:
+            # https://github.com/coreos/coreos-overlay/commit/68f8f060f41a70a6120ac33e7866dbd2367dfec5
+            comm.sudo("touch /etc/environment")
+
             temp = Tempfile.new("coreos-vagrant")
             temp.write(cfg)
             temp.close


### PR DESCRIPTION
A fix [0] was merged to coreos-overlay last night, but it is not yet in any released images. Without it, the coreos-cloudinit-vagrant.service unit will fail to run, leaving VMs completely unprovisioned. This is a temporary measure to allow coreos-cloudinit services to run like they used to.

Fix #56

[0] https://github.com/coreos/coreos-overlay/commit/68f8f060f41a70a6120ac33e7866dbd2367dfec5
