### PR TITLE
refactor(Vagrantfile): Check for NUM_INSTANCES returns 0 if not set

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 require_relative 'override-plugin.rb'
 
-NUM_INSTANCES = ENV['NUM_INSTANCES'].to_i || 1
+NUM_INSTANCES = ENV['NUM_INSTANCES'] || 1
 
 CLOUD_CONFIG_PATH = "./user-data"
 


### PR DESCRIPTION
Not versed well in Ruby, but the check returns 0, preventing iteration for coreos if it's not set in my environment variables.
