### PR TITLE
refactor(Vagrantfile): NUM_INSTANCES variable would return 0 if not set

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 require_relative 'override-plugin.rb'
 
-NUM_INSTANCES = ENV['NUM_INSTANCES'].to_i || 1
+NUM_INSTANCES = (ENV['NUM_INSTANCES'].to_i > 0 && ENV['NUM_INSTANCES'].to_i) || 1
 
 CLOUD_CONFIG_PATH = "./user-data"
 


### PR DESCRIPTION
Sorry about the previous commit.  As I said, not a Ruby pro, but this works whether the env variable is set or not.
