### PR TITLE
added environment variables for network configuration

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ CLOUD_CONFIG_PATH = "./user-data"
 CONFIG= "config.rb"
 
 # Defaults for config options defined in CONFIG
-$num_instances = [ Dir[".vagrant/machines/*"].count, 1 ].max
+$num_instances = 1
 $enable_serial_logging = false
 
 $ip_cnet = "172.17.8"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,9 @@ $ip_cnet = "172.17.8"
 $ip_base = 100
 $ip_incr = 1
 
+$core_folder = nil
+$host_folder = nil
+
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
 if ENV["NUM_INSTANCES"].to_i > 0 && ENV["NUM_INSTANCES"]
@@ -72,8 +75,9 @@ Vagrant.configure("2") do |config|
 
       config.vm.network :private_network, ip: ip
 
-      # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
-      #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      if $core_folder != nil and $host_folder != nil then
+        config.vm.synced_folder "#{$host_folder}", "#{$core_folder}", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      end
 
       if File.exist?(CLOUD_CONFIG_PATH)
         config.vm.provision :file, :source => "#{CLOUD_CONFIG_PATH}", :destination => "/tmp/vagrantfile-user-data"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,9 +10,10 @@ CONFIG= "config.rb"
 # Defaults for config options defined in CONFIG
 $num_instances = 1
 $enable_serial_logging = false
-$ip_cnet="172.17.8"
-$ip_base=100
-$ip_incr=1
+
+$ip_cnet = "172.17.8"
+$ip_base = 100
+$ip_incr = 1
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,9 +76,8 @@ Vagrant.configure("2") do |config|
 
       config.vm.network :private_network, ip: ip
 
-      if $core_folder != nil and $host_folder != nil then
-        config.vm.synced_folder "#{$host_folder}", "#{$core_folder}", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
-      end
+      # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
+      #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
 
       if File.exist?(CLOUD_CONFIG_PATH)
         config.vm.provision :file, :source => "#{CLOUD_CONFIG_PATH}", :destination => "/tmp/vagrantfile-user-data"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,6 @@ $enable_serial_logging = false
 
 $ip_cnet = "172.17.8"
 $ip_base = 100
-$ip_incr = 1
 
 $core_folder = nil
 $host_folder = nil
@@ -73,7 +72,7 @@ Vagrant.configure("2") do |config|
         end
       end
 
-      ip = "#{$ip_cnet}.#{i*$ip_incr+$ip_base}"
+      ip = "#{$ip_cnet}.#{$ip_base+i}"
 
       config.vm.network :private_network, ip: ip
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,9 +14,6 @@ $enable_serial_logging = false
 $ip_cnet = "172.17.8"
 $ip_base = 100
 
-$core_folder = nil
-$host_folder = nil
-
 $cluster_name = "core"
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ CLOUD_CONFIG_PATH = "./user-data"
 CONFIG= "config.rb"
 
 # Defaults for config options defined in CONFIG
-$num_instances = 1
+$num_instances = [ Dir[".vagrant/machines/*"].count, 1 ].max
 $enable_serial_logging = false
 
 $ip_cnet = "172.17.8"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,7 @@ if ENV["NUM_INSTANCES"].to_i > 0 && ENV["NUM_INSTANCES"]
 end
 
 if File.exist?(CONFIG)
-	require_relative CONFIG
+  require_relative CONFIG
 end
 
 Vagrant.configure("2") do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ $ip_base = 100
 $core_folder = nil
 $host_folder = nil
 
-$name_base = "core"
+$cluster_name = "core"
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
@@ -49,7 +49,7 @@ Vagrant.configure("2") do |config|
   end
 
   (1..$num_instances).each do |i|
-    config.vm.define vm_name = "#{$name_base}-%02d" % i do |config|
+    config.vm.define vm_name = "#{$cluster_name}-%02d" % i do |config|
       config.vm.hostname = vm_name
 
       if $enable_serial_logging

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # # vi: set ft=ruby :
 
 require 'fileutils'
+require 'netaddr'
 require_relative 'override-plugin.rb'
 
 CLOUD_CONFIG_PATH = "./user-data"
@@ -11,7 +12,7 @@ CONFIG= "config.rb"
 $num_instances = 1
 $enable_serial_logging = false
 
-$ip_cnet = "172.17.8"
+$ip_addr = "172.17.8.0/24"
 $ip_base = 100
 
 $cluster_name = "core"
@@ -45,6 +46,8 @@ Vagrant.configure("2") do |config|
     config.vbguest.auto_update = false
   end
 
+  $ip_cidr = NetAddr::CIDR.create($ip_addr)
+
   (1..$num_instances).each do |i|
     config.vm.define vm_name = "#{$cluster_name}-%02d" % i do |config|
       config.vm.hostname = vm_name
@@ -69,7 +72,7 @@ Vagrant.configure("2") do |config|
         end
       end
 
-      ip = "#{$ip_cnet}.#{$ip_base+i}"
+      ip = $ip_cidr[$ip_base+i].ip
 
       config.vm.network :private_network, ip: ip
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,8 @@ $ip_incr = 1
 $core_folder = nil
 $host_folder = nil
 
+$name_base = "core"
+
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
 if ENV["NUM_INSTANCES"].to_i > 0 && ENV["NUM_INSTANCES"]
@@ -48,7 +50,7 @@ Vagrant.configure("2") do |config|
   end
 
   (1..$num_instances).each do |i|
-    config.vm.define vm_name = "core-%02d" % i do |config|
+    config.vm.define vm_name = "#{$name_base}-%02d" % i do |config|
       config.vm.hostname = vm_name
 
       if $enable_serial_logging

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -16,3 +16,6 @@
 #$ip_base=100
 #$ip_incr=1
 
+# Shared folder configuration
+#host_folder=nil
+#core_folder=nil

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -15,9 +15,5 @@
 #$ip_cnet="172.17.8"
 #$ip_base=100
 
-# Shared folder configuration
-#$host_folder=nil
-#$core_folder=nil
-
 # Machine name configuration
 #$name_base="core"

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -16,4 +16,4 @@
 #$ip_base=100
 
 # Machine name configuration
-#$name_base="core"
+#$cluster_name="core"

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -12,7 +12,7 @@
 #$enable_serial_logging=false
 
 # IP address configuration
-#$ip_cnet="172.17.8"
+#$ip_addr="172.17.8.0/24"
 #$ip_base=100
 
 # Machine name configuration

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -5,7 +5,6 @@
 # after the equals sign..
 
 # Size of the CoreOS cluster created by Vagrant
-# Defaults to the number of machines created in the .vagrant/machines directory.
 #$num_instances=1
 
 # Log the serial consoles of CoreOS VMs to log/

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -5,6 +5,7 @@
 # after the equals sign..
 
 # Size of the CoreOS cluster created by Vagrant
+# Defaults to the number of machines created in the .vagrant/machines directory.
 #$num_instances=1
 
 # Log the serial consoles of CoreOS VMs to log/
@@ -17,5 +18,5 @@
 #$ip_incr=1
 
 # Shared folder configuration
-#host_folder=nil
-#core_folder=nil
+#$host_folder=nil
+#$core_folder=nil

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -20,3 +20,6 @@
 # Shared folder configuration
 #$host_folder=nil
 #$core_folder=nil
+
+# Machine name configuration
+#$name_base="core"

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -15,7 +15,6 @@
 # IP address configuration
 #$ip_cnet="172.17.8"
 #$ip_base=100
-#$ip_incr=1
 
 # Shared folder configuration
 #$host_folder=nil


### PR DESCRIPTION
`IP_CNET`, `IP_BASE` and `IP_INCR` together with `NUM_INSTANCES` can be used to generate incremental IP addresses for your cloud.

example:
```
export IP_CNET="10.0.0"
export IP_BASE=10
export IP_INCR=1
export NUM_INSTANCES=3
```
will generate the IP addresses `10.0.0.11`, `10.0.0.12` and `10.0.0.13`.
