### PR TITLE
Disable serial logging by default

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ require 'fileutils'
 require_relative 'override-plugin.rb'
 
 NUM_INSTANCES = (ENV['NUM_INSTANCES'].to_i > 0 && ENV['NUM_INSTANCES'].to_i) || 1
-SERIAL = true
+SERIAL = false
 
 CLOUD_CONFIG_PATH = "./user-data"
 


### PR DESCRIPTION
The serial console logging causes VirtualBox to consume an immense amount of CPU, making coreos-vagrant nearly unusable. Disabling it by default treats the problem until VirtualBox can fix the problem
upstream.

Fix #86
