### PR TITLE
Add ability to port-forward TCP docker service to host machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,10 @@ Vagrant.configure("2") do |config|
         end
       end
 
+      if $expose_docker_tcp
+        config.vm.network "forwarded_port", guest: 4243, host: $expose_docker_tcp, auto_correct: true
+      end
+
       config.vm.provider :virtualbox do |vb|
         vb.gui = $vb_gui
         vb.memory = $vb_memory

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -11,6 +11,13 @@
 # Enable by setting value to true, disable with false
 #$enable_serial_logging=false
 
+# Enable port forwarding of Docker TCP socket
+# Set to the TCP port you want exposed on the *host* machine, default is 4243
+# If 4243 is used, Vagrant will auto-increment (e.g. in the case of $num_instances > 1)
+# You can then use the docker tool locally by setting the folloing env var:
+#   export DOCKER_HOST='tcp://127.0.0.1:4243'
+#$expose_docker_tcp=4243
+
 # Setting for VirtualBox VMs
 #$vb_gui = false
 #$vb_memory = 1024

--- a/user-data.sample
+++ b/user-data.sample
@@ -19,3 +19,17 @@ coreos:
         [Service]
         Environment=FLEET_PUBLIC_IP=$public_ipv4
         ExecStart=/usr/bin/fleet
+    - name: docker-tcp.socket
+      command: start
+      enable: true
+      content: |
+        [Unit]
+        Description=Docker Socket for the API
+
+        [Socket]
+        ListenStream=4243
+        Service=docker.service
+        BindIPv6Only=both
+
+        [Install]
+        WantedBy=sockets.target


### PR DESCRIPTION
Based on information from here:

http://coreos.com/docs/launching-containers/building/customizing-docker/#enable-the-remote-api-on-a-new-socket

I use boot2docker right now, but would like to use CoreOS as my target  platform for building docker containers.  This change mimics what boot2docker does, forwards docker's service port to the host machine so that you can use the docker tools if you're not using Linux as a host workstation.

e.g.:

```
~/src/coreos-vagrant master ✔
🍺   uname -s
Darwin

~/src/coreos-vagrant master ✔
🍺   docker info
Containers: 0
Images: 0
Storage Driver: btrfs
Execution Driver: native-0.1
Kernel Version: 3.14.1+
```
