### PR TITLE
if exposing docker api locally use a unique port for each box in the cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,13 @@ Simply remove the old box file and vagrant will download the latest one the next
 vagrant box remove coreos --provider vmware_fusion
 vagrant box remove coreos --provider virtualbox
 ```
+
+## Docker Forwarding
+
+By setting the `$expose_docker_tcp` configuration value you can forward a local TCP port to docker on
+each CoreOS machine that you launch. The first machine will be available on the port that you specify
+and each additional machine will increment the port by 1.
+
+You can then use the `docker` command from your local shell by setting `DOCKER_HOST`:
+
+    export DOCKER_HOST=tcp://localhost:4243

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -63,7 +63,7 @@ Vagrant.configure("2") do |config|
       end
 
       if $expose_docker_tcp
-        config.vm.network "forwarded_port", guest: 4243, host: $expose_docker_tcp, auto_correct: true
+        config.vm.network "forwarded_port", guest: 4243, host: ($expose_docker_tcp + i - 1), auto_correct: true
       end
 
       config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
Without this change vagrant will not let you `suspend` and then `resume` a multi-box cluster that is forwarding the docker port. You will get the following error message:

```
Vagrant cannot forward the specified ports on this VM, since they
would collide with some other application that is already listening
on these ports. The forwarded port to 4243 is already in use
on the host machine.

To fix this, modify your current projects Vagrantfile to use another
port. Example, where '1234' would be replaced by a unique host port:

  config.vm.network :forwarded_port, guest: 4243, host: 1234

Sometimes, Vagrant will attempt to auto-correct this for you. In this
case, Vagrant was unable to. This is usually because the guest machine
is in a state which doesn't allow modifying port forwarding.
```
