### PR TITLE
feat(Vagrantfile): alter configuration to allow use as Docker host vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,13 @@ Vagrant.configure("2") do |config|
     override.vm.box_url = "http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_vagrant_vmware_fusion.json"
   end
 
+  config.vm.provider :virtualbox do |v|
+    # On VirtualBox, we don't have guest additions or a functional vboxsf
+    # in CoreOS, so tell Vagrant that so it can be smarter.
+    v.check_guest_additions = false
+    v.functional_vboxsf     = false
+  end
+
   # plugin conflict
   if Vagrant.has_plugin?("vagrant-vbguest") then
     config.vbguest.auto_update = false


### PR DESCRIPTION
turning off guest additions and vboxsf makes this possible, which is taken directly from the default docker host configuration: https://github.com/mitchellh/vagrant/blob/master/plugins/providers/docker/hostmachine/Vagrantfile
