### PR TITLE
alpha is a string, and needs quoting

### DIFF
--- a/config.rb.sample
+++ b/config.rb.sample
@@ -8,7 +8,7 @@
 #$num_instances=1
 
 # Official CoreOS channel from which updates should be downloaded
-#$update_channel=alpha
+#$update_channel='alpha'
 
 # Log the serial consoles of CoreOS VMs to log/
 # Enable by setting value to true, disable with false


### PR DESCRIPTION
Just quoting a string, so it doesn't break if used.
