### PR TITLE
Docker Forwarding Doc Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ and each additional machine will increment the port by 1.
 You can then use the `docker` command from your local shell by setting `DOCKER_HOST`:
 
     export DOCKER_HOST=tcp://localhost:4243
+
+Review and follow the [Enable Remote API instructions][coreos-enabling-port-forwarding] to get the CoreOS VM setup to work with port forwarding.
+
+[coreos-enabling-port-forwarding]: https://coreos.com/docs/launching-containers/building/customizing-docker/#enable-the-remote-api-on-a-new-socket


### PR DESCRIPTION
Update the Docker Forwarding portion of the README.md to include a link to the CoreOS documentation on enabling remote api ports, which is an essential step when trying to get Docker Forwarding working.
