### PR TITLE
Convert to the official IANA port for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,4 +103,4 @@ and each additional machine will increment the port by 1.
 
 You can then use the `docker` command from your local shell by setting `DOCKER_HOST`:
 
-    export DOCKER_HOST=tcp://localhost:4243
+    export DOCKER_HOST=tcp://localhost:2375

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,7 +70,7 @@ Vagrant.configure("2") do |config|
       end
 
       if $expose_docker_tcp
-        config.vm.network "forwarded_port", guest: 4243, host: ($expose_docker_tcp + i - 1), auto_correct: true
+        config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
       end
 
       config.vm.provider :vmware_fusion do |vb|

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -17,11 +17,11 @@
 #$enable_serial_logging=false
 
 # Enable port forwarding of Docker TCP socket
-# Set to the TCP port you want exposed on the *host* machine, default is 4243
-# If 4243 is used, Vagrant will auto-increment (e.g. in the case of $num_instances > 1)
+# Set to the TCP port you want exposed on the *host* machine, default is 2375
+# If 2375 is used, Vagrant will auto-increment (e.g. in the case of $num_instances > 1)
 # You can then use the docker tool locally by setting the following env var:
-#   export DOCKER_HOST='tcp://127.0.0.1:4243'
-#$expose_docker_tcp=4243
+#   export DOCKER_HOST='tcp://127.0.0.1:2375'
+#$expose_docker_tcp=2375
 
 # Setting for VirtualBox VMs
 #$vb_gui = false

--- a/user-data.sample
+++ b/user-data.sample
@@ -27,7 +27,7 @@ coreos:
         Description=Docker Socket for the API
 
         [Socket]
-        ListenStream=4243
+        ListenStream=2375
         Service=docker.service
         BindIPv6Only=both
 


### PR DESCRIPTION
Set all the defaults to use the new, official IANA port for Docker.

https://github.com/dotcloud/docker/issues/1440
