### PR TITLE
add minimum version requirement to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,8 @@
 
 require 'fileutils'
 
+Vagrant.require_version ">= 1.6.0"
+
 CLOUD_CONFIG_PATH = File.join(File.dirname(__FILE__), "user-data")
 CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 


### PR DESCRIPTION
From a fresh VM boot (used to work on v343.0.0):

```
><> vu
Bringing machine 'core-01' up with 'virtualbox' provider...
==> core-01: Box 'coreos-alpha' could not be found. Attempting to find and install...
    core-01: Box Provider: virtualbox
    core-01: Box Version: >= 308.0.1
==> core-01: Loading metadata for box 'http://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json'
    core-01: URL: http://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json
==> core-01: Adding box 'coreos-alpha' (v349.0.0) for provider: virtualbox
    core-01: Downloading: http://alpha.release.core-os.net/amd64-usr/349.0.0/coreos_production_vagrant.box
==> core-01: Successfully added box 'coreos-alpha' (v349.0.0) for 'virtualbox'!
There are errors in the configuration of this machine. Please fix
the following errors and try again:

VirtualBox Provider:
* The following settings shouldn't exist: functional_vboxsf
```

Version info:

```
OSX 10.9.3 (Mavericks)
Virtualbox 4.3.10r93012
vagrant 1.5.3
coreos v349.0.0
```
