### PR TITLE
pedantic capitalization fixes: VirtualBox & VMware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # CoreOS Vagrant
 
-This repo provides a template Vagrantfile to create a CoreOS virtual machine using the Virtualbox software hypervisor.
+This repo provides a template Vagrantfile to create a CoreOS virtual machine using the VirtualBox software hypervisor.
 After setup is complete you will have a single CoreOS virtual machine running on your local machine.
 
 ## Streamlined setup
 
 1) Install dependencies
 
-* [Virtualbox][virtualbox] 4.3.10 or greater.
+* [VirtualBox][virtualbox] 4.3.10 or greater.
 * [Vagrant][vagrant] 1.6 or greater.
 
 2) Clone this project and get it running!
@@ -22,18 +22,18 @@ cd coreos-vagrant
 There are two "providers" for Virtualbox with slightly different instructions.
 Follow one of the following two options:
 
-**Virtualbox Provider**
+**VirtualBox Provider**
 
-The Virtualbox provider is the default Vagrant provider. Use this if you are unsure.
+The VirtualBox provider is the default Vagrant provider. Use this if you are unsure.
 
 ```
 vagrant up
 vagrant ssh
 ```
 
-**VMWare Provider**
+**VMware Provider**
 
-The VMWare provider is a commercial addon from Hashicorp that offers better stability and speed.
+The VMware provider is a commercial addon from Hashicorp that offers better stability and speed.
 If you use this provider follow these instructions.
 
 ```


### PR DESCRIPTION
The capitalization they each use on their respective web sites is [VirtualBox](https://www.virtualbox.org/) and [VMware](http://www.vmware.com/) (ignoring when it's part of their logotype, in which case it's all lowercase).

I left one example of "Virtualbox" to avoid a merge conflict with my other pull request.  (I'm assuming you'll accept that one, but if you don't, and accept only this, then you'll want to manually fix that.... or I can send a third if you'd like.)
