### PR TITLE
Add VirtualBox minimum version warning to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,13 @@
 
 require 'fileutils'
 
+begin
+  unless VagrantPlugins::ProviderVirtualBox::Driver::Meta.new.version >= "4.3.10"
+    puts 'WARNING: If you are using the VirtualBox provider, please note that ersion 4.3.10 or greater is required.'
+  end
+rescue Vagrant::Errors::VirtualBoxNotDetected
+end
+
 CLOUD_CONFIG_PATH = File.join(File.dirname(__FILE__), "user-data")
 CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 


### PR DESCRIPTION
The documentation mentions that "VirtualBox provider, version 4.3.10 or greater is required.".

When testing CoreOs with an older version of VirtualBox I had difficulties getting etcd communicate in the cluster. After upgrading to VirtualBox 4.3.10 the issues went away.

This pull-request adds a warning when the VirtualBox provider minimum version is not met. Sadly it's not possible to get the provider used from inside the Vagrantfile (https://github.com/mitchellh/vagrant/issues/1867) so the warning will show even if the vmware provider is used (and VirtualBox installed).

