### PR TITLE
Support for vmware_workstation and customizing vmware memory/CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,15 @@ vagrant ssh
 The VMware provider is a commercial addon from Hashicorp that offers better stability and speed.
 If you use this provider follow these instructions.
 
+VMware Fusion:
 ```
 vagrant up --provider vmware_fusion
+vagrant ssh
+```
+
+VMware Workstation:
+```
+vagrant up --provider vmware_workstation
 vagrant ssh
 ```
 
@@ -92,6 +99,7 @@ Simply remove the old box file and vagrant will download the latest one the next
 
 ```
 vagrant box remove coreos --provider vmware_fusion
+vagrant box remove coreos --provider vmware_workstation
 vagrant box remove coreos --provider virtualbox
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ vagrant ssh
 ``vagrant ssh`` connects you to the virtual machine.
 Configuration is stored in the directory so you can always return to this machine by executing vagrant ssh from the directory where the Vagrantfile was located.
 
-3) Get started [using CoreOS][using-coreos]
+4) Get started [using CoreOS][using-coreos]
 
 [virtualbox]: https://www.virtualbox.org/
 [vagrant]: http://downloads.vagrantup.com/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,8 +31,10 @@ Vagrant.configure("2") do |config|
   config.vm.box_version = ">= 308.0.1"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel
 
-  config.vm.provider :vmware_fusion do |vb, override|
-    override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
+  ["vmware_fusion", "vmware_workstation"].each do |vmware|
+    config.vm.provider vmware do |v, override|
+      override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
+    end
   end
 
   config.vm.provider :virtualbox do |v|
@@ -58,11 +60,13 @@ Vagrant.configure("2") do |config|
         serialFile = File.join(logdir, "%s-serial.txt" % vm_name)
         FileUtils.touch(serialFile)
 
-        config.vm.provider :vmware_fusion do |v, override|
-          v.vmx["serial0.present"] = "TRUE"
-          v.vmx["serial0.fileType"] = "file"
-          v.vmx["serial0.fileName"] = serialFile
-          v.vmx["serial0.tryNoRxLoss"] = "FALSE"
+        ["vmware_fusion", "vmware_workstation"].each do |vmware|
+          config.vm.provider vmware do |v, override|
+            v.vmx["serial0.present"] = "TRUE"
+            v.vmx["serial0.fileType"] = "file"
+            v.vmx["serial0.fileName"] = serialFile
+            v.vmx["serial0.tryNoRxLoss"] = "FALSE"
+          end
         end
 
         config.vm.provider :virtualbox do |vb, override|
@@ -75,8 +79,10 @@ Vagrant.configure("2") do |config|
         config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
       end
 
-      config.vm.provider :vmware_fusion do |vb|
-        vb.gui = $vb_gui
+      ["vmware_fusion", "vmware_workstation"].each do |vmware|
+        config.vm.provider vmware do |v|
+          v.gui = $vb_gui
+        end
       end
 
       config.vm.provider :virtualbox do |vb|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,6 +82,8 @@ Vagrant.configure("2") do |config|
       ["vmware_fusion", "vmware_workstation"].each do |vmware|
         config.vm.provider vmware do |v|
           v.gui = $vb_gui
+          v.vmx["memsize"] = $vb_memory
+          v.vmx["numvcpus"] = $vb_cpus
         end
       end
 


### PR DESCRIPTION
Hey there, these are some quick changes to:

1. add support for the `vmware_workstation` provider
2. enable customizing memory/CPUs in vmware fusion/workstation using the existing `$vb_memory` and `$vb_cpus` config options
3. update README instructions accordingly (and a minor correction for setup step numbering)