### PR TITLE
Add basic support for parallels provider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,6 +42,20 @@ Vagrant.configure("2") do |config|
     v.functional_vboxsf     = false
   end
 
+  config.vm.provider :parallels do |vb, override|
+      if $update_channel == "alpha"
+	  override.vm.box = "yungsang/coreos-alpha"
+      elsif $update_channel == "beta"
+	  override.vm.box = "yungsang/coreos"
+      else
+	  raise "Update channel '%s' is not supported" % $update_channel
+      end
+      # yungsang's version 0.9.0 is based on CoreOS 310.1.0,
+      # which satisfies ">= 308.0.1".
+      override.vm.box_version = ">= 0.9.0"
+      override.vm.box_url = override.vm.box
+  end
+
   # plugin conflict
   if Vagrant.has_plugin?("vagrant-vbguest") then
     config.vbguest.auto_update = false
@@ -81,6 +95,13 @@ Vagrant.configure("2") do |config|
 
       config.vm.provider :virtualbox do |vb|
         vb.gui = $vb_gui
+        vb.memory = $vb_memory
+        vb.cpus = $vb_cpus
+      end
+
+      config.vm.provider :parallels do |vb|
+	# Headless mode is not supported by PD9,
+	# see https://github.com/Parallels/vagrant-parallels/issues/39
         vb.memory = $vb_memory
         vb.cpus = $vb_cpus
       end


### PR DESCRIPTION
Add basic support for parallels provider.

Known issue, if the box is not located on your machine, vagrant will download, but it will fail to clone it. As a result the whole `vagrant up` command fails with:

> There was an error while command execution. The command and stderr is shown below.
> 
> Command: ["prlctl", "clone", "3184bac2-ee6d-49d9-9155-af05d5c5b0be", "--name", "CoreOS Box_1406150828708_77818"]
> 
> Stderr:
> Failed to clone the VM: Unable to complete the operation for the virtual machine "CoreOS Box". The virtual machine ID is invalid. To resolve the problem, remove the virtual machine from the list and add it again.

But if you run `vagrant up` again, everything works just fine.

I don't know how to fix the issue, and it's not really critical. If you guys know how to fix, I'll glad to hear.