### PR TITLE
Add share_home config option

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 $num_instances = 1
 $update_channel = "alpha"
 $enable_serial_logging = false
+$share_home = false
 $vb_gui = false
 $vb_memory = 1024
 $vb_cpus = 1
@@ -101,6 +102,10 @@ Vagrant.configure("2") do |config|
 
       # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
       #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+
+      if $share_home
+        config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      end
 
       if File.exist?(CLOUD_CONFIG_PATH)
         config.vm.provision :file, :source => "#{CLOUD_CONFIG_PATH}", :destination => "/tmp/vagrantfile-user-data"

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -43,6 +43,11 @@ $new_discovery_url='https://discovery.etcd.io/new'
 #   export DOCKER_HOST='tcp://127.0.0.1:2375'
 #$expose_docker_tcp=2375
 
+# Enable NFS sharing of your home directory ($HOME) to CoreOS
+# It will be mounted at the same path in the VM as on the host.
+# Example: /Users/foobar -> /Users/foobar
+#$share_home=false
+
 # Setting for VirtualBox VMs
 #$vb_gui = false
 #$vb_memory = 1024


### PR DESCRIPTION
This is the approach used by docker-osx and fig.  After adding this and setting `$share_home=true` in `config.rb`, I can use fig in the same way with CoreOS.