### PR TITLE
ref(user-data.sample): configure fleet without overwriting unit file

### DIFF
--- a/user-data.sample
+++ b/user-data.sample
@@ -2,24 +2,18 @@
 
 coreos:
   etcd:
-      # generate a new token for each unique cluster from https://discovery.etcd.io/new
-      # WARNING: replace each time you 'vagrant destroy'
-      #discovery: https://discovery.etcd.io/<token>
-      addr: $public_ipv4:4001
-      peer-addr: $public_ipv4:7001
+    # generate a new token for each unique cluster from https://discovery.etcd.io/new
+    # WARNING: replace each time you 'vagrant destroy'
+    #discovery: https://discovery.etcd.io/<token>
+    addr: $public_ipv4:4001
+    peer-addr: $public_ipv4:7001
+  fleet:
+    public-ip: $public_ipv4
   units:
     - name: etcd.service
       command: start
     - name: fleet.service
       command: start
-      runtime: no
-      content: |
-        [Unit]
-        Description=fleet
-
-        [Service]
-        Environment=FLEET_PUBLIC_IP=$public_ipv4
-        ExecStart=/usr/bin/fleet
     - name: docker-tcp.socket
       command: start
       enable: true


### PR DESCRIPTION
We can configure the fleet public_ip with cloud-config, so let's do that
without overwriting the default unit.
