### PR TITLE
Automatically acquire a new etcd discovery token

### DIFF
--- a/config.rb.sample
+++ b/config.rb.sample
@@ -1,3 +1,25 @@
+
+# To automatically replace the discovery token on 'vagrant up', uncomment
+# the lines below:
+#
+#if File.exists? 'user-data'
+#  require 'open-uri'
+#  require 'yaml'
+# 
+#  token = open('https://discovery.etcd.io/new').read
+# 
+#  data = YAML.load(IO.readlines('user-data')[1..-1].join)
+#  data['coreos']['etcd']['discovery'] = token
+# 
+#  lines = YAML.dump(data).split("\n")
+#  lines[0] = '#cloud-config'
+# 
+#  open('user-data', 'r+') do |f|
+#    f.puts(lines.join("\n"))
+#  end
+#end
+#
+#
 # coreos-vagrant is configured through a series of configuration
 # options (global ruby variables) which are detailed below. To modify
 # these options, first copy this file to "config.rb". Then simply


### PR DESCRIPTION
Since we're loading a ruby file anyway, might as well automate the manual step away
