### PR TITLE
Only generate new etcd token on vagrant up

### DIFF
--- a/config.rb.sample
+++ b/config.rb.sample
@@ -2,7 +2,7 @@
 # To automatically replace the discovery token on 'vagrant up', uncomment
 # the lines below:
 #
-#if File.exists? 'user-data'
+#if File.exists?('user-data') && ARGV[0].eql?('up')
 #  require 'open-uri'
 #  require 'yaml'
 # 


### PR DESCRIPTION
Small enhancement to my previous commit to only generate a token on vagrant 'up'

As previously written, the token will be generated on all vagrant commands.

Signed-off-by: Christian Romney cromney@pointslope.com
