### PR TITLE
Add the ability to disable NFS in vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ $share_home = false
 $vm_gui = false
 $vm_memory = 1024
 $vm_cpus = 1
+$nfs_enable = true
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
@@ -42,6 +43,9 @@ def vm_cpus
 end
 
 Vagrant.configure("2") do |config|
+  # Do we want Vagrant to consider NFS as an option?
+  config.nfs.functional = $enable_nfs
+
   # always use Vagrants insecure key
   config.ssh.insert_key = false
 

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -57,3 +57,7 @@ $new_discovery_url='https://discovery.etcd.io/new'
 #$vm_gui = false
 #$vm_memory = 1024
 #$vm_cpus = 1
+
+# Allow Vagrant to use NFS for shared folders (default).
+# Set to false to force Vagrant to fall back to a different approach.
+#$enable_nfs = true


### PR DESCRIPTION
Using the Vagrant 1.6.5. Docker provider with VMware Fusion, seems to have issues properly detecting the technology to use for shared folders. There is a bug against Vagrant for this (since 1.6.3) here: https://github.com/mitchellh/vagrant/issues/4011

In the meantime, it looks like this additional configuration allows one to work around it, by forcefully disabling NFS, so that vagrant falls back to rsync.