### PR TITLE
Provide a way to customise prefix of the VMs name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 
 # Defaults for config options defined in CONFIG
 $num_instances = 1
+$instance_name_prefix = "core"
 $update_channel = "alpha"
 $enable_serial_logging = false
 $share_home = false
@@ -67,7 +68,7 @@ Vagrant.configure("2") do |config|
   end
 
   (1..$num_instances).each do |i|
-    config.vm.define vm_name = "core-%02d" % i do |config|
+    config.vm.define vm_name = "%s-%02d" % [$instance_name_prefix, i] do |config|
       config.vm.hostname = vm_name
 
       if $enable_serial_logging

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -27,6 +27,11 @@ $new_discovery_url='https://discovery.etcd.io/new'
 # Size of the CoreOS cluster created by Vagrant
 #$num_instances=1
 
+# Change basename of the VM
+# The default value is "core", which results in VMs named starting with
+# "core-01" through to "core-${num_instances}".
+#$instance_name_prefix="core"
+
 # Official CoreOS channel from which updates should be downloaded
 #$update_channel='alpha'
 


### PR DESCRIPTION
Currently if you use this repo for multiple project, you will have to destroy VMs when switching between projects, as the Vagrant relies on their names. The proposed change would allow one to pause VMs when switching between projects. With the base IPs still hardcoded in Vagrantfile, one cannot keep them running. However, with this change, they don't have to kill them.