### PR TITLE
Use virtio network interfaces in virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,12 @@ Vagrant.configure("2") do |config|
     override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json" % $update_channel
   end
 
+  config.vm.provider :virtualbox do |vb, override|
+    # Use paravirtualized network adapters
+    vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+    vb.customize ["modifyvm", :id, "--nictype2", "virtio"]
+  end
+
   config.vm.provider :virtualbox do |v|
     # On VirtualBox, we don't have guest additions or a functional vboxsf
     # in CoreOS, so tell Vagrant that so it can be smarter.


### PR DESCRIPTION
The [**virtio**](https://www.virtualbox.org/manual/ch06.html) paravirtualized adapter is well-supported and more efficient than virtualized NICs in VirtualBox. It is the default for boot2docker, for example, and fixes in [CoreOS 459.0.0](https://github.com/coreos/manifest/releases/tag/v459.0.0) make it reliable to use now.

@marineam [had also suggested](https://github.com/coreos/coreos-overlay/pull/900#issuecomment-57751782) that virtio should become the default.
