### PR TITLE
Expose docker port according to coreos guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ By setting the `$expose_docker_tcp` configuration value you can forward a local 
 each CoreOS machine that you launch. The first machine will be available on the port that you specify
 and each additional machine will increment the port by 1.
 
-Follow the [Enable Remote API instructions][coreos-enabling-port-forwarding] to get the CoreOS VM setup to work with port forwarding.
-
-[coreos-enabling-port-forwarding]: https://coreos.com/docs/launching-containers/building/customizing-docker/#enable-the-remote-api-on-a-new-socket
-
 Then you can then use the `docker` command from your local shell by setting `DOCKER_HOST`:
 
     export DOCKER_HOST=tcp://localhost:2375

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -95,6 +95,8 @@ Vagrant.configure("2") do |config|
 
       if $expose_docker_tcp
         config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
+        config.vm.provision :file, :source => "docker-tcp.socket", :destination => "/tmp/docker-tcp.socket"
+        config.vm.provision :shell, :inline => "mv /tmp/docker-tcp.socket /etc/systemd/system; systemctl enable docker-tcp.socket; systemctl stop docker; systemctl start docker-tcp.socket; systemctl start docker", :privileged => true, :keep_color => true
       end
 
       ["vmware_fusion", "vmware_workstation"].each do |vmware|

--- a/docker-tcp.socket
+++ b/docker-tcp.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=Docker Socket for the API
+
+[Socket]
+ListenStream=2375
+BindIPv6Only=both
+Service=docker.service
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Implemented https://coreos.com/docs/launching-containers/building/customizing-docker/#enable-the-remote-api-on-a-new-socket so there is no need for everyone to search for it and implement. See #121,  #125, https://github.com/coreos/coreos-vagrant/issues/132