### PR TITLE
always use Vagrants insecure key

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,9 @@ if File.exist?(CONFIG)
 end
 
 Vagrant.configure("2") do |config|
+  # always use Vagrants insecure key
+  config.ssh.insert_key = false
+
   config.vm.box = "coreos-%s" % $update_channel
   config.vm.box_version = ">= 308.0.1"
   config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % $update_channel


### PR DESCRIPTION
Vagrant 1.7 introduced a new feature that replaces the publicly known key with a newly generated one [[1]](https://twitter.com/mitchellh/status/525704126647128064). This fails with more than one VM (the key will get updated only in the first VM).

Arguably that is a bug in Vagrant but since it shouldn't matter for the use case of this box the practical solution is to just disable this feature...
