### PR TITLE
Allow sharing multiple directories via config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ $share_home = false
 $vm_gui = false
 $vm_memory = 1024
 $vm_cpus = 1
+$shared_folders = {}
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
@@ -116,6 +117,9 @@ Vagrant.configure("2") do |config|
 
       # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
       #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      $shared_folders.each_with_index do |(host_folder, guest_folder), index|
+        config.vm.synced_folder host_folder.to_s, guest_folder.to_s, id: "core-share%02d" % index, nfs: true, mount_options: ['nolock,vers=3,udp']
+      end
 
       if $share_home
         config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ['nolock,vers=3,udp']

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -57,3 +57,10 @@ $new_discovery_url='https://discovery.etcd.io/new'
 #$vm_gui = false
 #$vm_memory = 1024
 #$vm_cpus = 1
+
+# Share additional folders to the CoreOS VMs
+# For example,
+# $shared_folders = {'/path/on/host' => '/path/on/guest', '/home/foo/app' => '/app'}
+# or, to map host folders to guest folders of the same name,
+# $shared_folders = Hash[*['/home/foo/app1', '/home/foo/app2'].map{|d| [d, d]}.flatten]
+#$shared_folders = {}


### PR DESCRIPTION
Use case: multiple codebases wishing to share resources from one machine/cluster. Folders are mapped to the same location on guest and host, so that tools like `fig` can use the same config on guest and host.