### PR TITLE
Docker Image Caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.vagrant/
-log/
-user-data
+shared
+.vagrant
 config.rb
+user-data

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true,  :mou
 
 After a 'vagrant reload' you will be prompted for your local machine password.
 
+#### Docker Images 
+
+The Vagrantfile will provision your CoreOS VM(s) with a list of docker images from dockerhub before loading your user-data. These are configurable in your `config.rb` file.
+
+#### Docker Image Cache
+
+To avoid redownloading docker images each time your CoreOS VM(s) are built the Vagrantfile offers the ability to mount the docker directory (/var/lib/docker) as a loop device which is reused each time you run `vagrant up`. To enable this set the `$cache_docker_images` variable to true in `config.rb`
+
 #### Provisioning with user-data
 
 The Vagrantfile will provision your CoreOS VM(s) with [coreos-cloudinit][coreos-cloudinit] if a `user-data` file is found in the project directory.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -129,9 +129,6 @@ Vagrant.configure("2") do |config|
       ip = "172.17.8.#{i+100}"
       config.vm.network :private_network, ip: ip
 
-      # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
-      #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
-
       if $share_home
         config.vm.synced_folder ENV['HOME'], ENV['HOME'], id: "home", :nfs => true, :mount_options => ['nolock,vers=3,udp']
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,8 @@ $share_home = false
 $vm_gui = false
 $vm_memory = 1024
 $vm_cpus = 1
+$auto_discovery=false
+$new_discovery_url='https://discovery.etcd.io/new'
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
@@ -26,6 +28,19 @@ end
 
 if File.exist?(CONFIG)
   require CONFIG
+end
+
+if $auto_discovery.eql?(true) && File.exists?('user-data') && ARGV[0].eql?('up')
+  require 'open-uri'
+  require 'yaml'
+
+  token = open($new_discovery_url).read
+
+  data = YAML.load(IO.readlines('user-data')[1..-1].join)
+  data['coreos']['etcd']['discovery'] = token
+
+  yaml = YAML.dump(data)
+  File.open('user-data', 'w') { |file| file.write("#cloud-config\n\n#{yaml}") }
 end
 
 # Use old vb_xxx config variables when set

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -41,6 +41,25 @@
 # Example: /Users/foobar -> /Users/foobar
 #$share_home=false
 
+# Enable caching of the vm docker directory to allow for persistent
+# installation of docker images. This avoids having to redownload images
+# while testing your cloud-init setup
+#$cache_docker_images=false
+
+# Configure the size of the device to mount as the vm docker directory
+# The filesystem used for docker, btrfs, is known to fail when disk space
+# is running low. If you are getting Error: "No space left on device" (ENOSPC)
+# try increasing the size of the device.
+# [See documentation for coreutils 'dd' command for information on valid sizes]
+#$docker_device_size = '10G'
+
+# Provide a list of docker images to install on the vm before loading user-data.
+# This will allow for cleaner journal logs while testing since all necesary
+# images are already present before starting any tasks.
+#$docker_images = [
+#  "ubuntu:12.04"
+#]
+
 # Customize VMs
 #$vm_gui = false
 #$vm_memory = 1024

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -1,28 +1,16 @@
-$new_discovery_url='https://discovery.etcd.io/new'
-
-# To automatically replace the discovery token on 'vagrant up', uncomment
-# the lines below:
-#
-#if File.exists?('user-data') && ARGV[0].eql?('up')
-#  require 'open-uri'
-#  require 'yaml'
-# 
-#  token = open($new_discovery_url).read
-# 
-#  data = YAML.load(IO.readlines('user-data')[1..-1].join)
-#  data['coreos']['etcd']['discovery'] = token
-# 
-#  yaml = YAML.dump(data)
-#  File.open('user-data', 'w') { |file| file.write("#cloud-config\n\n#{yaml}") }
-#end
-#
-
-#
 # coreos-vagrant is configured through a series of configuration
 # options (global ruby variables) which are detailed below. To modify
 # these options, first copy this file to "config.rb". Then simply
 # uncomment the necessary lines, leaving the $, and replace everything
 # after the equals sign..
+
+# If you'd like to use a discovery url other than the one provided by CoreOS
+# Set it here:
+#$new_discovery_url='https://discovery.etcd.io/new'
+
+# To automatically replace the discovery token on 'vagrant up', set this
+# to true:
+#$auto_discovery=false
 
 # Size of the CoreOS cluster created by Vagrant
 #$num_instances=1

--- a/scripts/docker-device.sh
+++ b/scripts/docker-device.sh
@@ -1,0 +1,24 @@
+echo 'Stopping Docker Service'
+systemctl stop docker.service 2>/dev/null
+
+echo 'Removing Old Device'
+mountpoint -q /var/lib/docker && umount /var/lib/docker
+if [[ -n $(losetup /dev/loop0 2>/dev/null) ]]; then losetup -d /dev/loop0; fi
+
+if [ ! -f $1 ]
+  then
+    echo 'Creating New Device Image'
+    dd if=/dev/zero of=$1 bs=1 count=1 seek=$2
+    losetup /dev/loop0 $1
+    mkfs.btrfs -f /dev/loop0
+  else
+    echo 'Image Found. Creating Loop Device'
+    truncate -s $2 $1
+    losetup /dev/loop0 $1
+fi
+
+echo 'Mounting Device'
+mkdir -p /var/lib/docker && mount -t btrfs /dev/loop0 /var/lib/docker
+
+echo 'Starting Docker Service'
+systemctl start docker.service


### PR DESCRIPTION
I've been working with this project to test out my cloud-init setups for CoreOS on virtualbox. However I quickly found that decently complicated setups which involved more than a few basic docker images were problematicly slow to test. Without any ability to cache the docker images between builds I'd wind up waiting between 10 and 20 minutes to small changes. It was silly, so here's an alternative.

This PR adds two configurable additions to the Vagrantfile. 

- Pre-provision the VM(s) With a list of docker images before loading the user-data. You can provide the list of images in `config.rb` which your cloud-init depends on. These are then pulled from dockerhub with the vagrant docker provisioner prior to loading the user-data file. Of course you CAN setup your cloud-init file to download them itself, but I discovered this can be handy for cleaner testing.
- Replace the btrfs partition of the CoreOS VM(s) with a loop device build from an image saved on the host machine, allowing the device to persist between builds. The loop image is created as a sparse file with a maximum size configurable in `config.rb`. 

This cuts down the load time to close to 5% of the original time (total estimate but it seems accurate from the examples I've tested with.

**Note** I have only test this with the virtualbox provider since I don't have VMware.