### PR TITLE
add $share_work_dir flag for mounting cwd in coreos

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -115,8 +115,14 @@ Vagrant.configure("2") do |config|
       ip = "172.17.8.#{i+100}"
       config.vm.network :private_network, ip: ip
 
-      # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.
-      #config.vm.synced_folder ".", "/home/core/share", id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      if $share_work_dir
+        config.vm.synced_folder ".", "/home/core/share", {
+          id: "core",
+          nfs: true,
+          mount_options: ['nolock,vers=3,udp']
+        }
+      end
+
       $shared_folders.each_with_index do |(host_folder, guest_folder), index|
         config.vm.synced_folder host_folder.to_s, guest_folder.to_s, id: "core-share%02d" % index, nfs: true, mount_options: ['nolock,vers=3,udp']
       end

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -58,6 +58,9 @@ $new_discovery_url='https://discovery.etcd.io/new'
 #$vm_memory = 1024
 #$vm_cpus = 1
 
+# Share the working directory with coreos-vagrant at /home/core/share
+# $share_work_dir = true
+
 # Share additional folders to the CoreOS VMs
 # For example,
 # $shared_folders = {'/path/on/host' => '/path/on/guest', '/home/foo/app' => '/app'}


### PR DESCRIPTION
This is to remove the need to touch the `Vagrantfile`, confining user changes to `config.rb` instead.