### PR TITLE
Fixed docker0 address conflict

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -112,7 +112,7 @@ Vagrant.configure("2") do |config|
         vb.cpus = vm_cpus
       end
 
-      ip = "172.17.8.#{i+100}"
+      ip = "172.19.8.#{i+100}"
       config.vm.network :private_network, ip: ip
 
       # Uncomment below to enable NFS for sharing the host machine into the coreos-vagrant VM.


### PR DESCRIPTION
## Description
docker0 default uses [172.17.42.1/16](https://docs.docker.com/articles/networking/#tldr), so setting address of host-only adapter to 172.17.8.* leads to conflict, and makes docker0 picking other address (usually 10.1.42.1).

## Solution
Changed default network of host-only adapter to 172.19.8.* (the next prime number, just my preference), actually any private network other than 172.17.1.1/16 works.

This may solve #82, #111, and #174.