### PR TITLE
flannel: use the correct network interface

### DIFF
--- a/user-data.sample
+++ b/user-data.sample
@@ -9,6 +9,8 @@ coreos:
     peer-addr: $public_ipv4:7001
   fleet:
     public-ip: $public_ipv4
+  flannel:
+    interface: $public_ipv4
   units:
     - name: etcd.service
       command: start


### PR DESCRIPTION
/cc @eyakubovich 

Is it ok to add the flannel/interface parameter even if flannel is not installed?
