### PR TITLE
add expose_fleet_tcp flag

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,8 +99,12 @@ Vagrant.configure("2") do |config|
         config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
       end
 
+      if $expose_fleet_tcp
+        config.vm.network "forwarded_port", guest: 4001, host: ($expose_fleet_tcp + i - 1), auto_correct: true
+      end
+
       $forwarded_ports.each do |guest, host|
-	config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
+        config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
       end
 
       ["vmware_fusion", "vmware_workstation"].each do |vmware|

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -6,12 +6,12 @@ $new_discovery_url='https://discovery.etcd.io/new'
 #if File.exists?('user-data') && ARGV[0].eql?('up')
 #  require 'open-uri'
 #  require 'yaml'
-# 
+#
 #  token = open($new_discovery_url).read
-# 
+#
 #  data = YAML.load(IO.readlines('user-data')[1..-1].join)
 #  data['coreos']['etcd']['discovery'] = token
-# 
+#
 #  yaml = YAML.dump(data)
 #  File.open('user-data', 'w') { |file| file.write("#cloud-config\n\n#{yaml}") }
 #end
@@ -47,6 +47,11 @@ $new_discovery_url='https://discovery.etcd.io/new'
 # You can then use the docker tool locally by setting the following env var:
 #   export DOCKER_HOST='tcp://127.0.0.1:2375'
 #$expose_docker_tcp=2375
+
+# Enable port forwarding for Fleet TCP socket. Set this to true, then use fleetctl
+# locally by setting the following env var:
+#   export FLEETCTL_ENDPOINT='tcp://127.0.0.1:4001'
+#$expose_fleet_tcp=4001
 
 # Enable NFS sharing of your home directory ($HOME) to CoreOS
 # It will be mounted at the same path in the VM as on the host.


### PR DESCRIPTION
I understand this can be done via `forwarded_ports`, but submitting this as it'll be consistent with having `expose_docker_tcp`, as `fleet` is a core service.