### PR TITLE
Fix `cloud-init` initialization failure if reboot-strategy set to 'off'

### DIFF
--- a/config.rb.sample
+++ b/config.rb.sample
@@ -21,6 +21,13 @@ $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 #    data['coreos']['etcd2']['discovery'] = token
 #  end
 #
+#  # Fix for YAML.load() converting reboot-strategy from 'off' to `false`
+#  if data['coreos']['update'].key? 'reboot-strategy'
+#     if data['coreos']['update']['reboot-strategy'] == false
+#          data['coreos']['update']['reboot-strategy'] = 'off'
+#       end
+#  end
+#
 #  yaml = YAML.dump(data)
 #  File.open('user-data', 'w') { |file| file.write("#cloud-config\n\n#{yaml}") }
 #end


### PR DESCRIPTION
Using config.rb to auto fetch new discovery url with reboot-strategy 'off' failed `cloud-init` initialization with error invalid value as YAML.load() converted 'off' to 'false'