### PR TITLE
fixes coreos.update.reboot-strategy missing user-data key resolves #258

### DIFF
--- a/config.rb.sample
+++ b/config.rb.sample
@@ -22,7 +22,7 @@ $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 #  end
 #
 #  # Fix for YAML.load() converting reboot-strategy from 'off' to `false`
-#  if data['coreos']['update'].key? 'reboot-strategy'
+#  if data['coreos'].key? 'update' and data['coreos']['update'].key? 'reboot-strategy'
 #     if data['coreos']['update']['reboot-strategy'] == false
 #          data['coreos']['update']['reboot-strategy'] = 'off'
 #       end
@@ -46,7 +46,7 @@ $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 #$instance_name_prefix="core"
 
 # Change the version of CoreOS to be installed
-# To deploy a specific version, simply set $image_version accordingly. 
+# To deploy a specific version, simply set $image_version accordingly.
 # For example, to deploy version 709.0.0, set $image_version="709.0.0".
 # The default value is "current", which points to the current version
 # of the selected channel


### PR DESCRIPTION
this will handle the case for config keys omitted is user-data