### PR TITLE
Add ability to port-forward etcd HTTP API to the host machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,6 +102,10 @@ Vagrant.configure("2") do |config|
         config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
       end
 
+      if $expose_etcd_tcp_port
+        config.vm.network "forwarded_port", guest: 2379, host: ($expose_etcd_tcp_port + i - 1), auto_correct: true
+      end
+
       $forwarded_ports.each do |guest, host|
         config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
       end

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -68,6 +68,11 @@ $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 #   export DOCKER_HOST='tcp://127.0.0.1:2375'
 #$expose_docker_tcp=2375
 
+# Enable port forwarding of etcd TCP port
+# Set to the TCP port you want exposed on the *host* machine, default is 2379
+# Vagrant will auto-increment (e.g. in the case of $num_instances > 1) the port
+#$expose_etcd_tcp_port=2379
+
 # Enable NFS sharing of your home directory ($HOME) to CoreOS
 # It will be mounted at the same path in the VM as on the host.
 # Example: /Users/foobar -> /Users/foobar


### PR DESCRIPTION
The Vagrantfile will check if $expose_etcd_tcp is set in config.rb, and will forwad the IANA assigned etcd port (2379) to the specified port on the host. If the $num_instances in config.rb is greater than 1 the specified port will be incremented for each additional host.