### PR TITLE
Fix nil dereference in example

### DIFF
--- a/config.rb.sample
+++ b/config.rb.sample
@@ -22,10 +22,12 @@ $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 #  end
 #
 #  # Fix for YAML.load() converting reboot-strategy from 'off' to `false`
-#  if data['coreos']['update'].key? 'reboot-strategy'
-#     if data['coreos']['update']['reboot-strategy'] == false
-#          data['coreos']['update']['reboot-strategy'] = 'off'
-#       end
+#  if data['coreos'].key? 'update'
+#     if data['coreos']['update'].key? 'reboot-strategy'
+#        if data['coreos']['update']['reboot-strategy'] == false
+#           data['coreos']['update']['reboot-strategy'] = 'off'
+#        end
+#     end
 #  end
 #
 #  yaml = YAML.dump(data)


### PR DESCRIPTION
The example user-data has no 'update' section, so simply using the
config.rb sample and user-data sample will fail w/ a nil dereference.
Guard against this.