### PR TITLE
Limit docker port forwarding to loopback interface of host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -99,7 +99,7 @@ Vagrant.configure("2") do |config|
       end
 
       if $expose_docker_tcp
-        config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
+        config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), host_ip: "127.0.0.1", auto_correct: true
       end
 
       $forwarded_ports.each do |guest, host|


### PR DESCRIPTION
When I excercised the NAT port-forwarding using docker, the virtualbox process would jump to 100% of one core and stay there. After I limited the port-forward to the loopback interface, the CPU usage remains normal. I think [this ticket](https://www.virtualbox.org/ticket/14389) is what I was experiencing.