### PR TITLE
forward ssh agent to easily ssh into the different machines

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,6 +47,8 @@ end
 Vagrant.configure("2") do |config|
   # always use Vagrants insecure key
   config.ssh.insert_key = false
+  # forward ssh agent to easily ssh into the different machines
+  config.ssh.forward_agent = true
 
   config.vm.box = "coreos-%s" % $update_channel
   if $image_version != "current"


### PR DESCRIPTION
when starting a cluster locally with vagrant it's likely that you want to jump between the different machines. with this config the local agent gets forwarded. so something like `fleetctl ssh <machine>` just works