### PR TITLE
Add support for identification of forwarded ports.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,8 +102,12 @@ Vagrant.configure("2") do |config|
         config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true
       end
 
-      $forwarded_ports.each do |guest, host|
-        config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
+      $forwarded_ports.each do |k,v|
+        if v.is_a?(Hash)
+          config.vm.network "forwarded_port", guest: v.keys[0], host: v.values[0], auto_correct: true, id: k
+        else
+          config.vm.network "forwarded_port", guest: k, host: v, auto_correct: true
+        end
       end
 
       ["vmware_fusion", "vmware_workstation"].each do |vmware|

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -85,5 +85,6 @@ end
 # $shared_folders = Hash[*['/home/foo/app1', '/home/foo/app2'].map{|d| [d, d]}.flatten]
 #$shared_folders = {}
 
-# Enable port forwarding from guest(s) to host machine, syntax is: { 80 => 8080 }, auto correction is enabled by default.
+# Enable port forwarding from guest(s) to host machine, syntax is: { 80 => 8080, 'ssh' => { 22 => 2223 } }, auto correction is enabled by default.
+# Using hash as the value makes key act as the "id:" allowing identification of ports.
 #$forwarded_ports = {}


### PR DESCRIPTION
I wanted to change default SSH port. When I did $forwarded_ports = {22 => 2050} I noticed that it did work but left the default SSH port forwarding in place as well. By using ":id ssh" argument the default can be correctly replaced. This pull request improves this particular behavior.

Signed-off-by: Matthew Valimaki <matthew.valimaki@gmail.com>