### PR TITLE
Use HTTPS URLs for box metadata files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,11 +52,11 @@ Vagrant.configure("2") do |config|
   if $image_version != "current"
       config.vm.box_version = $image_version
   end
-  config.vm.box_url = "http://%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant.json" % [$update_channel, $image_version]
+  config.vm.box_url = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant.json" % [$update_channel, $image_version]
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|
     config.vm.provider vmware do |v, override|
-      override.vm.box_url = "http://%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant_vmware_fusion.json" % [$update_channel, $image_version]
+      override.vm.box_url = "https://storage.googleapis.com/%s.release.core-os.net/amd64-usr/%s/coreos_production_vagrant_vmware_fusion.json" % [$update_channel, $image_version]
     end
   end
 


### PR DESCRIPTION
Addresses #281.

Note that this only makes Vagrant download the box's metadata file over HTTPS. Because HTTP URLs are in the metadata file, the box itself will be downloaded over HTTP. I left a comment in coreos/bugs#1032 since it's not something that can be fixed in this repository.