### PR TITLE
feat(cluster): optional local docker registry service

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,17 @@ Follow the [Enable Remote API instructions][coreos-enabling-port-forwarding] to 
 Then you can then use the `docker` command from your local shell by setting `DOCKER_HOST`:
 
     export DOCKER_HOST=tcp://localhost:2375
+
+## Local docker registry server
+
+If the `$local_docker_registry_server` configuration value is set to `true`, an additional virtual machine will be created with the docker registry service running on port 80. The service will be available in the cluster's virtual machine(s) as `registry.local`. You can use it like this:
+
+```
+vagrant ssh core-01
+docker pull busybox
+docker tag busybox registry.local/mybusybox
+docker push registry.local/mybusybox
+exit
+vagrant ssh core-02
+docker pull registry.local/mybusybox
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ $vm_memory = 1024
 $vm_cpus = 1
 $shared_folders = {}
 $forwarded_ports = {}
+$local_docker_registry_server = false
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
@@ -138,6 +139,18 @@ Vagrant.configure("2") do |config|
         config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
       end
 
+      if $local_docker_registry_server
+        config.vm.provision :shell, :inline => "echo '172.17.8.127 registry.local' > /etc/hosts"
+      end
+
+    end
+  end
+
+  if $local_docker_registry_server
+    config.vm.define vm_name = "registry" do |config|
+      config.vm.hostname = vm_name
+      config.vm.network :private_network, ip: "172.17.8.127"
+      config.vm.provision :shell, :inline => "docker run -d -p 80:5000 --restart=always --name registry registry:2"
     end
   end
 end

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -87,3 +87,6 @@ end
 
 # Enable port forwarding from guest(s) to host machine, syntax is: { 80 => 8080 }, auto correction is enabled by default.
 #$forwarded_ports = {}
+
+# Create a local docker registry server (available as registry.local) for the cluster.
+#$local_docker_registry_server = true

--- a/user-data.sample
+++ b/user-data.sample
@@ -41,3 +41,9 @@ coreos:
 
         [Install]
         WantedBy=sockets.target
+    - name: docker.service
+      drop-ins:
+      - name: 10-allow-local-registry.conf
+        content: |
+          [Service]
+          Environment="DOCKER_OPTS=--insecure-registry registry.local"


### PR DESCRIPTION
Spin up a VM with docker registry service running on port 80
(available to the cluster as `registry.local`).