### PR TITLE
added enable-docker-tcp.service (see comments for issue 1374)

### DIFF
--- a/user-data.sample
+++ b/user-data.sample
@@ -41,3 +41,19 @@ coreos:
 
         [Install]
         WantedBy=sockets.target
+    - name: enable-docker-tcp.service
+      command: start
+      enable: true
+      content: |
+        [Unit]
+        Description=Enable Docker Socket for the API
+
+        [Service]
+        ExecStartPre=/usr/bin/systemctl stop docker.socket
+        ExecStartPre=/usr/bin/systemctl stop docker-tcp.socket
+        ExecStartPre=/usr/bin/systemctl stop docker
+        ExecStart=/usr/bin/systemctl enable docker-tcp.socket
+        ExecStartPost=/usr/bin/systemctl start docker.socket
+        ExecStartPost=/usr/bin/systemctl start docker-tcp.socket
+        Type=oneshot
+        RemainAfterExit=true


### PR DESCRIPTION
After having some trouble to get Docker TCP Support i found Issue 1374. Within the comments i found the solution to add an enable-docker-tcp.service. It would have saved me time, if this solution would have been included from the beginning.