### PR TITLE
Docker swarm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ $vm_cpus = 1
 $vb_cpuexecutioncap = 100
 $shared_folders = {}
 $forwarded_ports = {}
+$docker_swarm = false
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
@@ -104,7 +105,7 @@ Vagrant.configure("2") do |config|
       if $expose_docker_tcp
         config.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), host_ip: "127.0.0.1", auto_correct: true
       end
-	  
+      
       $forwarded_ports.each do |guest, host|
         config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
       end
@@ -142,22 +143,23 @@ Vagrant.configure("2") do |config|
         config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
       end
 
-	  # configure docker-swarm
-	  if (i == 1)
-		config.vm.network "forwarded_port", guest: 3375, host: 3375, host_ip: "127.0.0.1", auto_correct: true
-		#start docker-swarm manager on first host
-		config.vm.provision "shell" do |s|
-			s.inline = "docker rm -f swarm-manager; true && docker run -d --name swarm-manager --net=host --restart always swarm:latest manage -H tcp://$1:3375 etcd://127.0.0.1:2379"
-			s.args = [ip]
-		end
-	  end
-  	  #start docker-swarm agent on all hosts
-	  config.vm.provision "shell" do |s|
-		s.inline = "docker rm -f swarm-agent; true && docker run -d --name swarm-agent --net=host --restart always swarm:latest join --addr=$1:2375 etcd://127.0.0.1:2379"
-		s.args = [ip]
-	  end
-	  # end of docker-swarm configuration		
-	  
+      # configure docker-swarm
+      if $docker_swarm
+          if (i == 1)
+            config.vm.network "forwarded_port", guest: 3375, host: 3375, host_ip: "127.0.0.1", auto_correct: true
+            #start docker-swarm manager on first host
+            config.vm.provision "shell" do |s|
+                s.inline = "docker rm -f swarm-manager; true && docker run -d --name swarm-manager --net=host --restart always swarm:latest manage -H tcp://$1:3375 etcd://127.0.0.1:2379"
+                s.args = [ip]
+            end
+          end
+          #start docker-swarm agent on all hosts
+          config.vm.provision "shell" do |s|
+            s.inline = "docker rm -f swarm-agent; true && docker run -d --name swarm-agent --net=host --restart always swarm:latest join --addr=$1:2375 etcd://127.0.0.1:2379"
+            s.args = [ip]
+          end
+      end
+      # end of docker-swarm configuration        
     end
   end
 end

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -68,6 +68,12 @@ end
 #   export DOCKER_HOST='tcp://127.0.0.1:2375'
 #$expose_docker_tcp=2375
 
+# Enable docker-swarm support.
+# If you enable it, the docker-swarm agent will be run on all instances. The docker-swarm
+# manager will be run on the first instance. You can access the docker-swarm on port 3375
+# of the first instance.
+#$docker_swarm=false
+
 # Enable NFS sharing of your home directory ($HOME) to CoreOS
 # It will be mounted at the same path in the VM as on the host.
 # Example: /Users/foobar -> /Users/foobar

--- a/user-data.sample
+++ b/user-data.sample
@@ -57,3 +57,9 @@ coreos:
 
         [Install]
         WantedBy=default.target
+    - name: docker.service
+      drop-ins:
+        - name: 10-docker-swarm.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=-H=0.0.0.0:2375 -H unix:///var/run/docker.sock --cluster-advertise eth1:2375 --cluster-store etcd://127.0.0.1:2379"

--- a/user-data.sample
+++ b/user-data.sample
@@ -62,4 +62,4 @@ coreos:
         - name: 10-docker-swarm.conf
           content: |
             [Service]
-            Environment="DOCKER_OPTS=-H=0.0.0.0:2375 -H unix:///var/run/docker.sock --cluster-advertise eth1:2375 --cluster-store etcd://127.0.0.1:2379"
+            Environment="DOCKER_OPTS=--cluster-advertise eth1:2375 --cluster-store etcd://127.0.0.1:2379"

--- a/user-data.sample
+++ b/user-data.sample
@@ -41,3 +41,19 @@ coreos:
 
         [Install]
         WantedBy=sockets.target
+    - name: start-docker-swarm.service
+      command: start
+      enable: true
+      content: |
+        [Unit]
+        Description=Start Containers for docker-swarm
+
+        [Service]
+        Restart=always
+        ExecStartPost=/usr/bin/docker start swarm-manager;true
+        ExecStart=/usr/bin/docker start swarm-agent 
+        ExecStop=/usr/bin/docker stop -t 2 swarm-agent 
+        ExecStopPost=/usr/bin/docker stop -t 2 swarm-manager;true
+
+        [Install]
+        WantedBy=default.target


### PR DESCRIPTION
I added the Support to enable a docker-swarm by Setting the flag $docker_swarm to true. If this flag is set, the following Settings are set while provisioning:
- Port 3375 in the first instance is forwared to the same port on the host
- Shell scripts are added to deploy the docker-swarm agent on all instances and the docker-swarm manager on the first instance
