### PR TITLE
Support Vagrant 1.9.3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,7 +106,7 @@ Vagrant.configure("2") do |config|
       end
 
       $forwarded_ports.each do |guest, host|
-        config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
+        config.vm.network "forwarded_port", guest: guest, host: host, host_ip: "127.0.0.1", auto_correct: true
       end
 
       ["vmware_fusion", "vmware_workstation"].each do |vmware|


### PR DESCRIPTION
Use 127.0.0.1 for host IP when unset and 0.0.0.0 is not available