### PR TITLE
feat(config): Add an option to specify custom instance names

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See `config.rb.sample` for more information.
 ## Cluster Setup
 
 Launching a CoreOS cluster on Vagrant is as simple as configuring `$num_instances` in a `config.rb` file to 3 (or more!) and running `vagrant up`.
+If you need the specific instance names, set `$custom_instance_names` to a list of name strings.
 Make sure you provide a fresh discovery URL in your `user-data` if you wish to bootstrap etcd in your cluster.
 
 ## New Box Versions

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,11 +33,6 @@ if File.exist?(CONFIG)
   require CONFIG
 end
 
-# Correct $num_instances if $custom_instance_names is set.
-if $custom_instance_names != nil
-  $num_instances = $custom_instance_names.size
-end
-
 # Use old vb_xxx config variables when set
 def vm_gui
   $vb_gui.nil? ? $vm_gui : $vb_gui

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 
 # Defaults for config options defined in CONFIG
 $num_instances = 1
+$custom_instance_names = nil
 $instance_name_prefix = "core"
 $update_channel = "alpha"
 $image_version = "current"
@@ -30,6 +31,11 @@ end
 
 if File.exist?(CONFIG)
   require CONFIG
+end
+
+# Correct $num_instances if $custom_instance_names is set.
+if $custom_instance_names != nil
+  $num_instances = $custom_instance_names.size
 end
 
 # Use old vb_xxx config variables when set
@@ -75,8 +81,14 @@ Vagrant.configure("2") do |config|
     config.vbguest.auto_update = false
   end
 
-  (1..$num_instances).each do |i|
-    config.vm.define vm_name = "%s-%02d" % [$instance_name_prefix, i] do |config|
+  # Use custom instance names or generate prefix-based ones.
+  instance_names = $custom_instance_names
+  if instance_names == nil
+    instance_names = (1..$num_instances).map { |i| "%s-%02d" % [$instance_name_prefix, i] }
+  end
+
+  instance_names.each_with_index do |name, i|
+    config.vm.define vm_name = name do |config|
       config.vm.hostname = vm_name
 
       if $enable_serial_logging

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -1,6 +1,9 @@
 # Size of the CoreOS cluster created by Vagrant
 $num_instances=1
 
+# If non-nil, this list of names will be used for instances.
+$custom_instance_names=nil
+
 # Used to fetch a new discovery token for a cluster of size $num_instances
 $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -4,6 +4,11 @@ $num_instances=1
 # If non-nil, this list of names will be used for instances.
 $custom_instance_names=nil
 
+# Correct $num_instances if $custom_instance_names is defined
+if $custom_instance_names != nil
+  $num_instances = $custom_instance_names.size
+end
+
 # Used to fetch a new discovery token for a cluster of size $num_instances
 $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 


### PR DESCRIPTION
Currently, instance names are generated from a customizable prefix.
Now, setting the variable `$custom_instance_names` to a non-nil list
of strings changes the variable `$num_instances` to a size of that
list and uses the specified names as an instance names.