### PR TITLE
fix the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -154,7 +154,7 @@ Vagrant.configure("2") do |config|
       # This shouldn't be used for the virtualbox provider (it doesn't have any effect if it is though)
       if File.exist?(CLOUD_CONFIG_PATH)
         config.vm.provision :file, :source => "#{CLOUD_CONFIG_PATH}", :destination => "/tmp/vagrantfile-user-data"
-        config.vm.provision :shell, :inline => "mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
+        config.vm.provision :shell, :inline => "mkdir -p /var/lib/coreos-vagrant; mv /tmp/vagrantfile-user-data /var/lib/coreos-vagrant/", :privileged => true
       end
 
       config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
the provisioning script fails with the message:

cannot create regular file '/var/lib/coreos-vagrant/
not a directory

This change provides a clean installation.