### PR TITLE
vagrantfile: update for vagrant-ignition 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,8 @@ Follow the [Enable Remote API instructions][coreos-enabling-port-forwarding] to 
 Then you can then use the `docker` command from your local shell by setting `DOCKER_HOST`:
 
     export DOCKER_HOST=tcp://localhost:2375
+
+## Troubleshooting
+If vagrant fails to run successfully, first make sure that the latest version of the coreos-vagrant project has been downloaded, then run
+`vagrant destroy -f` to remove old machines, `vagrant box update` to update the OS box, and `vagrant plugin update vagrant-ignition` to
+update the ignition plugin. If the problems persist after that, please report bugs at https://issues.coreos.com.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -159,8 +159,7 @@ Vagrant.configure("2") do |config|
 
       config.vm.provider :virtualbox do |vb|
         config.ignition.hostname = vm_name
-        config.ignition.config_vmdk = File.join(File.dirname(__FILE__), "config" + i.to_s  + ".vmdk")
-        config.ignition.config_img = "config" + i.to_s  + ".img"
+        config.ignition.drive_name = "config" + i.to_s
         # when the ignition config doesn't exist, the plugin automatically generates a very basic Ignition with the ssh key
         # and previously specified options (ip and hostname). Otherwise, it appends those to the provided config.ign below
         if File.exist?(IGNITION_CONFIG_PATH)


### PR DESCRIPTION
Vagrant-ignition 0.0.2 has some breaking changes. This updates the
Vagrantfile to be compatible with those changes.

Depends on https://github.com/coreos/vagrant-ignition/pull/3