### PR TITLE
Support IP address range

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,8 @@ $vm_cpus = 1
 $vb_cpuexecutioncap = 100
 $shared_folders = {}
 $forwarded_ports = {}
+$ip_range_start = '100'
+$ip_range_prefix = '172.17.8'
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it
@@ -136,7 +138,7 @@ Vagrant.configure("2") do |config|
         config.ignition.config_obj = vb
       end
 
-      ip = "172.17.8.#{i+100}"
+      ip = "#{$ip_range_prefix}.#{i + $ip_range_start.to_i - 1}"
       config.vm.network :private_network, ip: ip
       # This tells Ignition what the IP for eth1 (the host-only adapter) should be
       config.ignition.ip = ip

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -58,6 +58,15 @@ end
 #   export DOCKER_HOST='tcp://127.0.0.1:2375'
 #$expose_docker_tcp=2375
 
+# Set the final octet of the IP address
+# The first host will begin at ${ip_prefix}.${ip_range_start}
+# Each subsequent host will take the next IP address in the sequence
+# $ip_range_start = '100'
+
+# Set the IP address prefix for the VM
+# All hosts in the cluster will use the following prefix for the IP
+# $ip_range_prefix = '172.17.8'
+
 # Enable NFS sharing of your home directory ($HOME) to CoreOS
 # It will be mounted at the same path in the VM as on the host.
 # Example: /Users/foobar -> /Users/foobar


### PR DESCRIPTION
Allows configuring the IP address range so that the chosen IP addresses can
match existing DNS records as necessary.