### PR TITLE
add support for $update_channel to match coreos.com documentation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,7 @@ CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 
 # Defaults for config options defined in CONFIG
 $num_instances = 1
+$update_channel = "alpha"
 $instance_name_prefix = "core"
 $enable_serial_logging = false
 $share_home = false
@@ -63,12 +64,12 @@ Vagrant.configure("2") do |config|
   # forward ssh agent to easily ssh into the different machines
   config.ssh.forward_agent = true
 
-  config.vm.box = "coreos-alpha"
-  config.vm.box_url = "https://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant_virtualbox.json"
+  config.vm.box = "coreos-#{$update_channel}"
+  config.vm.box_url = "https://#{$update_channel}.release.core-os.net/amd64-usr/current/coreos_production_vagrant_virtualbox.json"
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|
     config.vm.provider vmware do |v, override|
-      override.vm.box_url = "https://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json"
+      override.vm.box_url = "https://#{$update_channel}.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json"
     end
   end
 

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -1,6 +1,9 @@
 # Size of the CoreOS cluster created by Vagrant
 $num_instances=1
 
+# Official CoreOS channel from which updates should be downloaded
+$update_channel='alpha'
+
 # Used to fetch a new discovery token for a cluster of size $num_instances
 $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 


### PR DESCRIPTION
These changes implement the `$update_channel` variable in `config.rb.sample` and `Vagrantfile` to match the [coreos.com documentation][coreos-docs-vagrant].

Setting the `$update_channel` variable in `config.rb` to `alpha`, `beta`, or `stable` will make Vagrant use the corresponding box of the official CoreOS release.

There is no change to the project's default behavior (`$update_channel` is set to `alpha` by default).

This pull request is comparable to pull request #310.

[coreos-docs-vagrant]: https://coreos.com/os/docs/latest/booting-on-vagrant.html#start-up-coreos-container-linux