### PR TITLE
config: add support for paravirtprovider

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,7 @@ $vm_gui = false
 $vm_memory = 1024
 $vm_cpus = 1
 $vb_cpuexecutioncap = 100
+$vb_paravirtprovider = "default"
 $shared_folders = {}
 $forwarded_ports = {}
 
@@ -133,6 +134,7 @@ Vagrant.configure("2") do |config|
         vb.memory = vm_memory
         vb.cpus = vm_cpus
         vb.customize ["modifyvm", :id, "--cpuexecutioncap", "#{$vb_cpuexecutioncap}"]
+        vb.customize ["modifyvm", :id, "--paravirtprovider", "#{$vb_paravirtprovider}"]
         config.ignition.config_obj = vb
       end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,7 @@ CONFIG = File.join(File.dirname(__FILE__), "config.rb")
 
 # Defaults for config options defined in CONFIG
 $num_instances = 1
+$update_channel = "alpha"
 $instance_name_prefix = "core"
 $enable_serial_logging = false
 $share_home = false
@@ -64,12 +65,12 @@ Vagrant.configure("2") do |config|
   # forward ssh agent to easily ssh into the different machines
   config.ssh.forward_agent = true
 
-  config.vm.box = "coreos-alpha"
-  config.vm.box_url = "https://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant_virtualbox.json"
+  config.vm.box = "coreos-#{$update_channel}"
+  config.vm.box_url = "https://#{$update_channel}.release.core-os.net/amd64-usr/current/coreos_production_vagrant_virtualbox.json"
 
   ["vmware_fusion", "vmware_workstation"].each do |vmware|
     config.vm.provider vmware do |v, override|
-      override.vm.box_url = "https://alpha.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json"
+      override.vm.box_url = "https://#{$update_channel}.release.core-os.net/amd64-usr/current/coreos_production_vagrant_vmware_fusion.json"
     end
   end
 

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -1,6 +1,9 @@
 # Size of the CoreOS cluster created by Vagrant
 $num_instances=1
 
+# Official CoreOS channel from which updates should be downloaded
+$update_channel='alpha'
+
 # Used to fetch a new discovery token for a cluster of size $num_instances
 $new_discovery_url="https://discovery.etcd.io/new?size=#{$num_instances}"
 

--- a/config.rb.sample
+++ b/config.rb.sample
@@ -68,6 +68,7 @@ end
 #$vm_memory = 1024
 #$vm_cpus = 1
 #$vb_cpuexecutioncap = 100
+#$vb_paravirtprovider = "default"
 
 # Share additional folders to the CoreOS VMs
 # For example,


### PR DESCRIPTION
this adds support for paravirtprovider property to set the
paravirtualization provider in virtualbox.
default value for paravirtprovider property is set to "default".

implements $vb_paravirtprovider variable in Vagrantfile and
config.rb.sample.

background:
with virtualbox on windows and vm_cpu > 1 boot process hangs during vagrant up at "SSH auth method: private key".
starting the vm directly from within oracle's virtualbox admin tool shows that booting hangs at "x86: Booting SMP configuration:".
reason is that coreos-vagrant doesn't set the vm's paravirtprovider property.
because of this the vm is created in virtualbox with  paravirtualization (under "system->acceleration) set to "legacy".
this iin turn causes the vm not to boot.